### PR TITLE
Adding method to convert PyTA output to Kotlin object (with tests)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,11 @@ version = properties("pluginVersion")
 repositories {
     mavenCentral()
 }
+dependencies {
+    implementation("org.junit.jupiter:junit-jupiter:5.7.0")
+}
+
+
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
@@ -51,6 +56,11 @@ qodana {
 }
 
 tasks {
+    // Use the native JUnit support of Gradle.
+    "test"(Test::class) {
+        useJUnitPlatform()
+    }
+
     // Set the JVM compatibility versions
     properties("javaVersion").let {
         withType<JavaCompile> {

--- a/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaIssue.kt
+++ b/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaIssue.kt
@@ -1,0 +1,33 @@
+package com.github.davidyzliu.pytapycharmplugin.utils
+
+data class PytaIssue(val filename: String, val msgs: Array<PytaMessage>) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PytaIssue
+
+        if (filename != other.filename) return false
+        if (!msgs.contentEquals(other.msgs)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = filename.hashCode()
+        result = 31 * result + msgs.contentHashCode()
+        return result
+    }
+
+}
+
+
+data class PytaMessage(
+    val symbol: String,
+    val msg: String,
+    val category: String,
+    val path: String,
+    val module: String,
+    val line: Int,
+    val column: Int
+)

--- a/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaIssue.kt
+++ b/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaIssue.kt
@@ -1,5 +1,10 @@
 package com.github.davidyzliu.pytapycharmplugin.utils
 
+/**
+ * Represents all issues identified by PyTA with a given file
+ * @property filename The name of the file which was scanned
+ * @property msgs An array of PytaMessage which contains information on each issue identified by PyTA with the file.
+ * */
 data class PytaIssue(val filename: String, val msgs: Array<PytaMessage>) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -22,6 +27,16 @@ data class PytaIssue(val filename: String, val msgs: Array<PytaMessage>) {
 }
 
 
+/**
+ * Represents a single PyTA issue and containing information about the issue identified by PyTA with a file
+ * @property symbol The symbol associated with the PyTA message which uniquely identifies the issue
+ * @property msg The string representing the issue with the file in human-readable form
+ * @property category The category of this issue identified by PyTA
+ * @property path The path with the file which was scanned (not absolute)
+ * @property module The module of the file
+ * @property line The line for which this message highlights the issue
+ * @property column The column for which this message highlights the issue
+ * */
 data class PytaMessage(
     val symbol: String,
     val msg: String,

--- a/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtils.kt
+++ b/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtils.kt
@@ -4,9 +4,21 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.lang.reflect.Type
 
+/**
+ * Contains utility methods used in the plugin.
+ *
+ * This class has a private constructor because the utility methods have *no state*.
+ * */
 class PytaPluginUtils private constructor () {
 
     companion object {
+
+        /**
+         * Parse the JSON string containing the results of a scan and return a list of Kotlin objects representing the
+         * issues.
+         * @param messageString The JSON string returned by PyTA after a scan.
+         * @return A list of PytaIssue containing results for each file that was used in the scan.
+         * */
         fun parsePytaOutputString(messageString: String): List<PytaIssue> {
             val gson = Gson()
             val issueListType: Type = object : TypeToken<List<PytaIssue>>() {}.type

--- a/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtils.kt
+++ b/src/main/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtils.kt
@@ -1,0 +1,18 @@
+package com.github.davidyzliu.pytapycharmplugin.utils
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
+
+class PytaPluginUtils private constructor () {
+
+    companion object {
+        fun parsePytaOutputString(messageString: String): List<PytaIssue> {
+            val gson = Gson()
+            val issueListType: Type = object : TypeToken<List<PytaIssue>>() {}.type
+            return gson.fromJson(messageString, issueListType)
+        }
+    }
+
+
+}

--- a/src/test/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtilsTest.kt
+++ b/src/test/kotlin/com/github/davidyzliu/pytapycharmplugin/utils/PytaPluginUtilsTest.kt
@@ -1,0 +1,151 @@
+package com.github.davidyzliu.pytapycharmplugin.utils
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class PytaPluginUtilsTest {
+
+    // A set of constants that will be used in the tests
+    companion object {
+        private const val SAMPLE_FILE_ONE = "sample_file_one.py"
+        private const val SAMPLE_FILE_TWO = "sample_file_two.py"
+
+        private const val SAMPLE_MESSAGE_ONE_FILE_ONE =
+            """
+             {
+                 "msg_id": "E0000",
+                 "symbol": "some-symbol",
+                 "msg": "This is a message",
+                 "C": "C",
+                 "category": "convention",
+                 "confidence": [
+                     "HIGH",
+                     "No false positive possible."
+                 ],
+                 "abspath": "$SAMPLE_FILE_ONE",
+                 "path": "$SAMPLE_FILE_ONE",
+                 "module": "some_module",
+                 "obj": "",
+                 "line": 1,
+                 "column": 0,
+                 "node": null,
+                 "snippet": "some_code_snippet",
+                 "line_end": 11,
+                 "column_end": 12
+            }
+        """
+
+        private val SAMPLE_MESSAGE_ONE_FILE_ONE_OBJECT =
+            PytaIssue(
+                SAMPLE_FILE_ONE,
+                arrayOf(
+                    PytaMessage(
+                        "some-symbol", "This is a message", "convention",
+                        "sample_file_one.py", "some_module",1, 0
+                    )
+                )
+            )
+
+        private const val SAMPLE_MESSAGE_TWO_FILE_ONE =
+            """
+             {
+                 "msg_id": "E0001",
+                 "symbol": "some-other-symbol",
+                 "msg": "This is another message",
+                 "C": "E",
+                 "category": "error",
+                 "confidence": [
+                     "HIGH",
+                     "No false positive possible."
+                 ],
+                 "abspath": "$SAMPLE_FILE_ONE",
+                 "path": "$SAMPLE_FILE_ONE",
+                 "module": "some_module",
+                 "obj": "",
+                 "line": 5,
+                 "column": 4,
+                 "node": null,
+                 "snippet": "another_code_snipped",
+                 "line_end": 5,
+                 "column_end": 20
+            }
+            """
+
+        const val SAMPLE_MESSAGE_ONE_FILE_TWO =
+            """
+             {
+                 "msg_id": "E0000",
+                 "symbol": "some-symbol",
+                 "msg": "This is a message",
+                 "C": "C",
+                 "category": "convention",
+                 "confidence": [
+                     "HIGH",
+                     "No false positive possible."
+                 ],
+                 "abspath": "$SAMPLE_FILE_TWO",
+                 "path": "$SAMPLE_FILE_TWO",
+                 "module": "some_module",
+                 "obj": "",
+                 "line": 1,
+                 "column": 0,
+                 "node": null,
+                 "snippet": "some_code_snippet",
+                 "line_end": 11,
+                 "column_end": 12
+            }
+            """
+    }
+
+    @Test
+    fun `PyTA Json string with single issue converted to Kotlin object`() {
+        val samplePytaOutput =
+            """
+                [
+                    {
+                        "filename": "$SAMPLE_FILE_ONE",
+                        "msgs": [$SAMPLE_MESSAGE_ONE_FILE_ONE]                    
+                    }
+                ]
+            """
+        val issues: List<PytaIssue> = PytaPluginUtils.parsePytaOutputString(samplePytaOutput)
+        assertEquals(listOf(SAMPLE_MESSAGE_ONE_FILE_ONE_OBJECT), issues)
+    }
+
+    @Test
+    fun `All messages for an issue present in Kotlin object`() {
+        val samplePytaOutput =
+            """
+               [
+                    {
+                        "filename": "$SAMPLE_FILE_ONE",
+                        "msgs": [$SAMPLE_MESSAGE_ONE_FILE_ONE, $SAMPLE_MESSAGE_ONE_FILE_TWO]
+                    }
+               ] 
+            """
+        val issues: List<PytaIssue> = PytaPluginUtils.parsePytaOutputString(samplePytaOutput)
+
+        assertEquals(1, issues.size)
+        assertEquals(2, issues[0].msgs.size)
+    }
+
+    @Test
+    fun `Multiple issues present in Kotlin object`() {
+        val samplePytaOutput =
+            """
+               [
+                    {
+                        "filename": "$SAMPLE_FILE_ONE",
+                        "msgs": [$SAMPLE_MESSAGE_ONE_FILE_ONE, $SAMPLE_MESSAGE_ONE_FILE_TWO]
+                    },
+                    {
+                        "filename": "$SAMPLE_FILE_TWO",
+                        "msgs": [$SAMPLE_MESSAGE_ONE_FILE_TWO]
+                    }
+               ] 
+            """
+        val issues: List<PytaIssue> = PytaPluginUtils.parsePytaOutputString(samplePytaOutput)
+
+        assertEquals(2, issues.size)
+    }
+}


### PR DESCRIPTION
## Motivation
To notify users about errors detected by PyTA in their python files, the plugin will first have to scan the required file(s). PyTA offers an option to get the results of the scan in a JSON format. Thus, there needs to be a way to convert this JSON output into a Kotlin object that can then be used to populate the UI that will display the results of the scan to the user. This is meant to accomplish that.

## Description
I have created a class called `PytaPluginUtils` which will contain static utility methods that are required by the plugin to operate. One of these methods is the `parsePytaOutputString` which takes a JSON string as an argument (where the JSON is obtained through the `JSONReporter` of PyTa) and returns a List of Kotlin objects encapsulating the most important results of the scan. The structure of the returned object is as follows:

- `PytaMessage`: The atomic unit of info which describes a single issue, which file it occurs in, and which lines it occurs at.
- `PytaIssue`: Is an organization of all messages given by PyTA by the filename. In other words, it contains all messages which informs users about all things that are incorrect with a particular file (as determined by PyTA). 

## Testing
I have added the following tests to make sure the parser functions correctly:
- Check all fields in a `PytaIssue` and `PytaMessage` have correct values for a given JSON string
- Check correct number of messages are available in a `PytaIssue` object
- Check correct number of issues are returned for a given JSON string.