### PR TITLE
Adding Ktlint support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
     id("org.jetbrains.changelog") version "1.3.0"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.12"
+    // Ktlint from repository - https://github.com/jlleitschuh/ktlint-gradle
+    id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
 }
 
 group = properties("pluginGroup")
@@ -23,11 +25,21 @@ version = properties("pluginVersion")
 repositories {
     mavenCentral()
 }
+
 dependencies {
     implementation("org.junit.jupiter:junit-jupiter:5.7.0")
 }
 
+// Do not accept publishing of build scan results. Can be changed to "yes" if needed in the future.
+extensions.findByName("buildScan")?.withGroovyBuilder {
+    setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
+    setProperty("termsOfServiceAgree", "no")
+}
 
+ktlint {
+    outputToConsole.set(true)
+    outputColorName.set("RED")
+}
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
@@ -95,11 +107,13 @@ tasks {
         )
 
         // Get the latest available change notes from the changelog file
-        changeNotes.set(provider {
-            changelog.run {
-                getOrNull(properties("pluginVersion")) ?: getLatest()
-            }.toHTML()
-        })
+        changeNotes.set(
+            provider {
+                changelog.run {
+                    getOrNull(properties("pluginVersion")) ?: getLatest()
+                }.toHTML()
+            }
+        )
     }
 
     runPluginVerifier {


### PR DESCRIPTION
## Description
The Ktlint plugin was needed in gradle to ensure consistency in code style across different contributions to the repository. This commimt introduces the Ktlint plugin for gradle to the project.

## Testing
- Verified that the `ktlintCheck` and `ktlintFormat` gradle tasks were added to the project
- `ktlintCheck` reports issues with offending files
- `ktlintFormat` is able to fix issues with offending files