### PR TITLE
Update platformType config to PyCharm Community Edition

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ pluginUntilBuild = 212.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1
 
-platformType = IC
+platformType = PC
 platformVersion = 2020.3.4
 platformDownloadSources = true
 


### PR DESCRIPTION
This affects what IDE is launched when testing the plugin. (Previously, was IntelliJ Community Edition, and is now PyCharm.)