### PR TITLE
Update Qodana version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2.1-eap
+        uses: JetBrains/qodana-action@v4.1.0
 
       # Run tests
       - name: Run Tests


### PR DESCRIPTION
This matches the latest Qodana version used in the template repository https://github.com/JetBrains/intellij-platform-plugin-template. Hopefully will fix the CI build.